### PR TITLE
FEAT: Created left/right tilt for arms control

### DIFF
--- a/arm_control/arm_control/human_arm_control.py
+++ b/arm_control/arm_control/human_arm_control.py
@@ -20,3 +20,49 @@ jointLowerLimits = [
 speed = 1 # TO BE SET LATER
 current_cycle_mode = 1 # TO BE SET LATER
 joint_control_is_active = True 
+
+def rightLeftTilt(joystick_input, button, cur_pose):
+    """Converts controller inputs from L2 and R2 
+       to left and right tilt at fixed position.
+    Parameters
+    --------
+        joystic_input : int
+            integer representing the controller input. 
+            Assume that value is normalized between -1.0 and 1.0.
+            Assume that L2 points left and R2 points right (relative to the current orientation)
+        joystick_button : int
+            integer that represent if the joystick input is L2 or R2.
+            L2 is represented by 3.
+            R2 is represented by 4.
+        cur_pose : list(float)
+            list of five joint angles representing the current pose
+    Returns
+    --------
+        target_pose : list(float)
+            list of five joint angles 
+    """
+    # Normalize joystick input from [-1, 1] to [0, 1]
+    input = (joystick_input + 1) / 2
+    input *= speed
+
+    # Compute current pitch
+    cur_mat = arm_kinematics.forwardKinematics(cur_pose)
+    cur_pose = arm_kinematics.Mat2Pose(cur_mat)
+    cur_euler = cur_pose[3:] # Extract Euler angles
+
+    # EXPLORE OTHER WAYS TO MAKE MOVEMENT SMOOTHER
+    if button == 3: # L2 controls (left)
+        cur_euler[2] -= input
+    elif button == 4: # R2 controls (right)
+        cur_euler[2] += input
+    else:
+        print("Unrecognized button")
+        return cur_pose # Return cur_pose unchanged
+
+    # Clamp pitch between maximum and minimum joint limits
+    cur_euler[2] = max(jointLowerLimits[0], min(cur_euler[2], jointUpperLimits[0]))
+
+    hand_pose = cur_pose[0:3] + cur_euler
+    target_pose = arm_kinematics.inverseKinematics(hand_pose, cur_pose)
+
+    return target_pose


### PR DESCRIPTION
**Description**
  Added implementation of up/down tilt by taking the current pose and computing a new pose with a modified pitch (up or down) and returning the pose after IK.

**Issues**
- Increment of pitch might not be the most optimal way.
- Naming of button (3 for L2 and 4 for R2) might not be optimal.
- Might need to recheck clamping to make sure that the joint taken is the right one.

**Assumptions**
- Assume that value is normalized between -1.0 and 1.0.
- Assume that L2 points left and R2 points right (relative to the current orientation).

Code has not been tested yet