### PR TITLE
Two gamepad input

### DIFF
--- a/control/scripts/firmware_node.py
+++ b/control/scripts/firmware_node.py
@@ -45,7 +45,7 @@ class firmware(Node):
         #Call electrical API to get current state of wheels
         self.wheel_angles = [math.pi/2]*4 #Dummy  value, update with API call
        
-        self.gamepadSubscriber = self.create_subscription(GamePadInput, "gamepad_input", self.controller_callback, 10)
+        self.gamepadSubscriber = self.create_subscription(GamePadInput, "gamepad_input_drive", self.controller_callback, 10)
 
         # IMPORTANT: Timer period cannot be too high that it exceeds router buffer 
         timer_period = 0.25

--- a/human_control_interface/src/gamepad.py
+++ b/human_control_interface/src/gamepad.py
@@ -45,6 +45,7 @@ class Gamepad():
         """
         # Data container for the Gamepad input data
         self.data = GamepadData()
+        self.arm_data = GamepadData()
 
         # Initialize Gamepad
         pygame.init()
@@ -55,6 +56,7 @@ class Gamepad():
             print("only one joystick")
             self.controller = pygame.joystick.Joystick(0)
             self.controller.init()
+            self.arm_controller = None
             print(pygame.joystick.get_count(), self.controller.get_id(),
                   " ", self.controller.get_name())
 
@@ -74,7 +76,12 @@ class Gamepad():
             except:
                 print(controller2.get_name(), "failed")
 
-            if controller1.get_id() == 0:
+            if controller1.get_id() == 0 and controller2.get_id() == 1:
+                print("2 controllers connected")
+                self.controller = controller1
+                self.arm_controller = controller2
+            
+            elif controller1.get_id() == 0:
                 self.controller = controller1
                 # print("gamepad initalize success")
             else:
@@ -111,6 +118,22 @@ class Gamepad():
                     self.data.b12 = self.controller.get_button(11)
                     self.data.b13 = self.controller.get_button(12)
 
+                    if self.arm_controller != None:
+                        #Update arm_data for buttons:
+                        self.arm_data.b1 = self.arm_controller.get_button(0)
+                        self.arm_data.b2 = self.arm_controller.get_button(1)
+                        self.arm_data.b3 = self.arm_controller.get_button(2)
+                        self.arm_data.b4 = self.arm_controller.get_button(3)
+                        self.arm_data.b5 = self.arm_controller.get_button(4)
+                        self.arm_data.b6 = self.arm_controller.get_button(5)
+                        self.arm_data.b7 = self.arm_controller.get_button(6)
+                        self.arm_data.b8 = self.arm_controller.get_button(7)
+                        self.arm_data.b9 = self.arm_controller.get_button(8)
+                        self.arm_data.b10 = self.arm_controller.get_button(9)
+                        self.arm_data.b11 = self.arm_controller.get_button(10)
+                        self.arm_data.b12 = self.arm_controller.get_button(11)
+                        self.arm_data.b13 = self.arm_controller.get_button(12)
+
                 elif an_event.type == pygame.JOYAXISMOTION:
                     self.data.a1 = self.controller.get_axis(0)
                     self.data.a2 = -1 * self.controller.get_axis(1)
@@ -119,6 +142,16 @@ class Gamepad():
                     self.data.a5 = -1 * self.controller.get_axis(4)
                     self.data.a6 = self.controller.get_axis(5)
                     self.data.a7 = self.controller.get_hat(0)
+
+                    if self.arm_controller != None:
+                        #Update arm_data for axes:
+                        self.arm_data.a1 = self.arm_controller.get_axis(0)
+                        self.arm_data.a2 = -1 * self.arm_controller.get_axis(1)
+                        self.arm_data.a3 = self.arm_controller.get_axis(2)
+                        self.arm_data.a4 = self.arm_controller.get_axis(3)
+                        self.arm_data.a5 = -1 * self.arm_controller.get_axis(4)
+                        self.arm_data.a6 = self.arm_controller.get_axis(5)
+                        self.arm_data.a7 = self.arm_controller.get_hat(0)
 
             except pygame.error:
                 pass

--- a/human_control_interface/src/gamepad.py
+++ b/human_control_interface/src/gamepad.py
@@ -61,6 +61,7 @@ class Gamepad():
                   " ", self.controller.get_name())
 
         elif pygame.joystick.get_count() == 2:
+            #Try to initialize both controllers
             try:
                 controller1 = pygame.joystick.Joystick(0)
                 controller1.init()
@@ -77,14 +78,16 @@ class Gamepad():
                 print(controller2.get_name(), "failed")
 
             if controller1.get_id() == 0 and controller2.get_id() == 1:
+                #If both controllers are correctly detected, initialize both fields
                 print("2 controllers connected")
                 self.controller = controller1
                 self.arm_controller = controller2
             
             elif controller1.get_id() == 0:
+                #If only one controller is correctly detected
                 self.controller = controller1
-                # print("gamepad initalize success")
             else:
+                #If the first controller 
                 self.controller = controller2
 
         else:

--- a/human_control_interface/src/gamepad_input_pub.py
+++ b/human_control_interface/src/gamepad_input_pub.py
@@ -33,9 +33,10 @@ class gamepad_input_publisher(Node):
                     raise Exception("Failed to connect to controller")
                 time.sleep(1)
 
-        #Declare publisher for Joystick msg
+        #Declare publishers for Joystick msgs to drive and arm nodes
         # self.gamepad_publisher = self.create_publisher(Joy, "gamepad_input", 10)
-        self.gamepad_publisher = self.create_publisher(GamePadInput, "gamepad_input", 10)
+        self.gamepad_publisher = self.create_publisher(GamePadInput, "gamepad_input_drive", 10)
+        self.arm_gamepad_publisher = self.create_publisher(GamePadInput, "gamepad_input_arm", 10)
 
         # Control frequency of the node
         timer_period = 1e-1
@@ -47,6 +48,7 @@ class gamepad_input_publisher(Node):
 
             self.gamepad.update()
             msg = GamePadInput()
+            arm_msg = GamePadInput()
 
             # Transfer Data into msg
 
@@ -71,8 +73,35 @@ class gamepad_input_publisher(Node):
             msg.r_stick_analog  = self.gamepad.data.a6
             msg.d_pad_x         = float(self.gamepad.data.a7[0])
             msg.d_pad_y         = float(self.gamepad.data.a7[1])
-            
+
             self.gamepad_publisher.publish(msg)
+            
+            if self.gamepad.arm_controller != None:
+                # Transfer Data into arm_msg
+
+                arm_msg.x_button        = self.gamepad.arm_data.b1
+                arm_msg.o_button        = self.gamepad.arm_data.b2
+                arm_msg.triangle_button = self.gamepad.arm_data.b3
+                arm_msg.square_button   = self.gamepad.arm_data.b4
+                arm_msg.l1_button       = self.gamepad.arm_data.b5
+                arm_msg.r1_button       = self.gamepad.arm_data.b6
+                arm_msg.l2_button       = self.gamepad.arm_data.b7
+                arm_msg.r2_button       = self.gamepad.arm_data.b8
+                arm_msg.select_button   = self.gamepad.arm_data.b9
+                arm_msg.start_button    = self.gamepad.arm_data.b10
+                arm_msg.home_button     = self.gamepad.arm_data.b11
+                arm_msg.l3_button       = self.gamepad.arm_data.b12
+                arm_msg.r3_button       = self.gamepad.arm_data.b13
+                arm_msg.l_stick_x       = self.gamepad.arm_data.a1
+                arm_msg.l_stick_y       = self.gamepad.arm_data.a2
+                arm_msg.l_stick_analog  = self.gamepad.arm_data.a3
+                arm_msg.r_stick_x       = self.gamepad.arm_data.a4
+                arm_msg.r_stick_y       = self.gamepad.arm_data.a5
+                arm_msg.r_stick_analog  = self.gamepad.arm_data.a6
+                arm_msg.d_pad_x         = float(self.gamepad.arm_data.a7[0])
+                arm_msg.d_pad_y         = float(self.gamepad.arm_data.a7[1])
+            
+                self.arm_gamepad_publisher.publish(arm_msg)
 
         except Exception as error:
                 print

--- a/human_control_interface/src/gamepad_input_pub.py
+++ b/human_control_interface/src/gamepad_input_pub.py
@@ -34,7 +34,6 @@ class gamepad_input_publisher(Node):
                 time.sleep(1)
 
         #Declare publishers for Joystick msgs to drive and arm nodes
-        # self.gamepad_publisher = self.create_publisher(Joy, "gamepad_input", 10)
         self.gamepad_publisher = self.create_publisher(GamePadInput, "gamepad_input_drive", 10)
         self.arm_gamepad_publisher = self.create_publisher(GamePadInput, "gamepad_input_arm", 10)
 


### PR DESCRIPTION
Extended the gamepad input node functionality to tolerate two simultaneous controllers. 
Each controller publishes to a different topic.
Updated the topic name to which the drive firmware node subscribes.