### PR TITLE
CSA Speed Limit

### DIFF
--- a/drive/scripts/speed_control.py
+++ b/drive/scripts/speed_control.py
@@ -13,6 +13,9 @@ class SpeedController():
 
     """
 
+    # SET BEFORE TESTING
+    csa_speed_limit = True
+
     def __init__(self, json_filename="max_wheel_speed_levels.json"):
         
         # (Mar.1, 2025) Max speed is 2000 rpm
@@ -35,6 +38,8 @@ class SpeedController():
                         "gear": 6,
                         "speed": 3200.0
                     }]
+        if csa_speed_limit:
+            self.gears = self.gears[:2]
 
         self.history_size : int = 3 # How many previous wheels we average over
 


### PR DESCRIPTION
Limits the number of gears if a hardcoded variable is set to true. I set it as a hardcoded variable to make it less likely for us to forget it. It's default set to true (and should stay that way!!! Do not push a change to the variable!!!) so that we have to actively set it to false before driving quickly. It's a safety feature to make sure we don't get kicked out of the CSA.